### PR TITLE
Add libSceSystemService to sysmodtab

### DIFF
--- a/crt/rtld.c
+++ b/crt/rtld.c
@@ -110,6 +110,7 @@ static struct sysmodtab {
   unsigned int handle;
 } sysmodtab[] = {
   {"libSceUserService.sprx", 0x80000011},
+  {"libSceSystemService.sprx", 0x80000010},
 };
 
 


### PR DESCRIPTION
Fixes an issue where the `sceSystemServiceLaunchApp` function returned 2157182977 (`SCE_LNC_UTIL_ERROR_NOT_INITIALIZED`).