### PR TITLE
Add cmake targets

### DIFF
--- a/.github/workflows/macos-latest.yml
+++ b/.github/workflows/macos-latest.yml
@@ -44,10 +44,22 @@ jobs:
           $MAKE -C samples/kdump
           $MAKE -C samples/mntinfo
           $MAKE -C samples/ps
-          $CMAKE -S samples/hello_cmake -B samples/hello_cmake/build
-          $CMAKE --build samples/hello_cmake/build
-          $MESON setup samples/hello_meson samples/hello_meson/build
-          $MESON compile -C samples/hello_meson/build
+        env:
+          LLVM_CONFIG: /opt/homebrew/opt/llvm@18/bin/llvm-config
+          PS4_PAYLOAD_SDK: ${{ runner.tool_cache }}/ps4-payload-sdk
+
+      - name: Build meson samples
+        run: |
+          $PS4_PAYLOAD_SDK/bin/orbis-meson setup samples/hello_meson samples/hello_meson/build
+          $PS4_PAYLOAD_SDK/bin/orbis-meson compile -C samples/hello_meson/build
+        env:
+          LLVM_CONFIG: /opt/homebrew/opt/llvm@18/bin/llvm-config
+          PS4_PAYLOAD_SDK: ${{ runner.tool_cache }}/ps4-payload-sdk
+
+      - name: Build cmake samples
+        run: |
+          $PS4_PAYLOAD_SDK/bin/orbis-cmake -S samples/hello_cmake -B samples/hello_cmake/build
+          $PS4_PAYLOAD_SDK/bin/orbis-cmake --build samples/hello_cmake/build
         env:
           LLVM_CONFIG: /opt/homebrew/opt/llvm@18/bin/llvm-config
           PS4_PAYLOAD_SDK: ${{ runner.tool_cache }}/ps4-payload-sdk

--- a/.github/workflows/ubuntu-latest.yml
+++ b/.github/workflows/ubuntu-latest.yml
@@ -53,10 +53,20 @@ jobs:
         $MAKE -C samples/kdump
         $MAKE -C samples/mntinfo
         $MAKE -C samples/ps
-        $CMAKE -S samples/hello_cmake -B samples/hello_cmake/build
-        $CMAKE --build samples/hello_cmake/build
-        $MESON setup samples/hello_meson samples/hello_meson/build
-        $MESON compile -C samples/hello_meson/build
+      env:
+          PS4_PAYLOAD_SDK: ${{ runner.tool_cache }}/ps4-payload-sdk
+
+    - name: Build meson samples
+      run: |
+        $PS4_PAYLOAD_SDK/bin/orbis-meson setup samples/hello_meson samples/hello_meson/build
+        $PS4_PAYLOAD_SDK/bin/orbis-meson compile -C samples/hello_meson/build
+      env:
+          PS4_PAYLOAD_SDK: ${{ runner.tool_cache }}/ps4-payload-sdk
+
+    - name: Build cmake samples
+      run: |
+        $PS4_PAYLOAD_SDK/bin/orbis-cmake -S samples/hello_cmake -B samples/hello_cmake/build
+        $PS4_PAYLOAD_SDK/bin/orbis-cmake --build samples/hello_cmake/build
       env:
           PS4_PAYLOAD_SDK: ${{ runner.tool_cache }}/ps4-payload-sdk
 

--- a/host/toolchain/orbis.cmake
+++ b/host/toolchain/orbis.cmake
@@ -63,5 +63,7 @@ set(CMAKE_AR ${PS4_PAYLOAD_SDK}/bin/orbis-ar CACHE PATH "")
 set(CMAKE_STRIP ${PS4_PAYLOAD_SDK}/bin/orbis-strip CACHE PATH "")
 set(CMAKE_RANLIB ${PS4_PAYLOAD_SDK}/bin/orbis-ranlib CACHE PATH "")
 
+set(PS4_DEPLOY ${PS4_PAYLOAD_SDK}/bin/orbis-deploy CACHE PATH "")
+
 set(PKG_CONFIG_EXECUTABLE ${PS4_PAYLOAD_SDK}/bin/orbis-pkg-config CACHE PATH "")
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)

--- a/samples/hello_cmake/CMakeLists.txt
+++ b/samples/hello_cmake/CMakeLists.txt
@@ -1,3 +1,19 @@
+#   Copyright (C) 2026 John Törnblom
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not see
+# <http://www.gnu.org/licenses/>.
+
 cmake_minimum_required(VERSION 3.5)
 
 if(NOT DEFINED ENV{PS4_PAYLOAD_SDK})

--- a/samples/hello_cmake/CMakeLists.txt
+++ b/samples/hello_cmake/CMakeLists.txt
@@ -1,8 +1,22 @@
 cmake_minimum_required(VERSION 3.5)
 
+if(NOT DEFINED ENV{PS4_PAYLOAD_SDK})
+    message(FATAL_ERROR "PS4_PAYLOAD_SDK is undefined")
+endif()
+
 project(hello_cmake C CXX)
 add_executable(hello_c main.c)
 add_executable(hello_cpp main.cpp)
 
 set_target_properties(hello_c PROPERTIES OUTPUT_NAME hello_c.elf)
 set_target_properties(hello_cpp PROPERTIES OUTPUT_NAME hello_cpp.elf)
+
+add_custom_target(test_c
+    COMMAND ${PS4_DEPLOY} hello_c.elf
+    DEPENDS hello_c
+)
+
+add_custom_target(test_cpp
+    COMMAND ${PS4_DEPLOY} hello_cpp.elf
+    DEPENDS hello_cpp
+)


### PR DESCRIPTION
can be tested with
```sh
$PS4_PAYLOAD_SDK/bin/orbis-cmake -S samples/hello_cmake -B samples/hello_cmake/build
$PS4_PAYLOAD_SDK/bin/orbis-cmake --build samples/hello_cmake/build --target test_c # test hello_c project
$PS4_PAYLOAD_SDK/bin/orbis-cmake --build samples/hello_cmake/build --target test_cpp # test hello_cpp project
```