### PR TITLE
cmake: enable `USES_TERMINAL`

### DIFF
--- a/samples/hello_cmake/CMakeLists.txt
+++ b/samples/hello_cmake/CMakeLists.txt
@@ -24,11 +24,13 @@ set_target_properties(hello_c PROPERTIES OUTPUT_NAME hello_c.elf)
 set_target_properties(hello_cpp PROPERTIES OUTPUT_NAME hello_cpp.elf)
 
 add_custom_target(test_c
+    USES_TERMINAL
     COMMAND ${PS4_DEPLOY} hello_c.elf
     DEPENDS hello_c
 )
 
 add_custom_target(test_cpp
+    USES_TERMINAL
     COMMAND ${PS4_DEPLOY} hello_cpp.elf
     DEPENDS hello_cpp
 )


### PR DESCRIPTION
Fixes TTY not displaying deploy output.